### PR TITLE
start to read args from 2 position and deleted extra validation

### DIFF
--- a/kartograph/cli.py
+++ b/kartograph/cli.py
@@ -23,17 +23,12 @@ def main():
         cfg = {}
         output = None
         opt_src = None
-        opts, args = getopt.getopt(sys.argv[3:], 'c:o:', ['config=', 'output='])
+        opts, args = getopt.getopt(sys.argv[2:], 'c:o:', ['config=', 'output='])
         for o, a in opts:
             if o in ('-c', '--config'):
                 opt_src = a
             elif o in ('-o', '--output'):
                 output = a
-
-        if opt_src is None and len(sys.argv) > 2:
-            opt_src = sys.argv[2]
-        else:
-            raise KartographError('you need to pass a map configuration (json/yaml)')
 
         # check and load map configuration
         if os.path.exists(opt_src):


### PR DESCRIPTION
This fixed the error 'configuration not found when you try to genera a svg map kartograph generate -c config.json -o mapworld.svg':

Traceback (most recent call last):
  File "/usr/local/bin/kartograph", line 8, in <module>
    load_entry_point('kartograph.py==0.1.6', 'console_scripts', 'kartograph')()
  File "/Library/Python/2.7/site-packages/kartograph.py-0.1.6-py2.7.egg/kartograph/cli.py", line 49, in main
    raise KartographError('configuration not found')
