### PR TITLE
Fixed OS X 10.7 install (again)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     namespace_packages=[],
     include_package_data=False,
     zip_safe=False,
-    install_requires=["pyshp", "polygon", "pyyaml"],
+    install_requires=["polygon==2.0.4", "pyshp", "pyyaml"],
     dependency_links=["https://github.com/downloads/jraedler/Polygon2/Polygon-2.0.4.zip"],
     tests_require=[],
     entry_points={


### PR DESCRIPTION
For some reason my previous fix wasn't enough to make it work on a machine where the install wasn't attempted before. Bloody Python dependency management! :)

This should work.
