### PR TITLE
When using a "crop-to" in a layer config an error is thrown due to not being able to find the referenced layer

### DIFF
--- a/kartograph/map.py
+++ b/kartograph/map.py
@@ -371,7 +371,7 @@ class Map(object):
                 for tocrop in layer.features:
                     cbbox = geom_to_bbox(tocrop.geom)
                     crop_at_layer = layer.options['crop-to']
-                    if crop_at_layer not in self.layers:
+                    if crop_at_layer not in self.layersById:
                         raise KartographError('you want to substract '
                             + 'from layer "%s" which cannot be found'
                             % crop_at_layer)


### PR DESCRIPTION
(https://github.com/kartograph/kartograph.py/blob/master/kartograph/map.py#L374)

this seems to be solvable by using self.layersById instead.
