### PR TITLE
Sometimes when using "crop-to" in a layer config an error is thrown due to a missing bbox

### DIFF
--- a/kartograph/map.py
+++ b/kartograph/map.py
@@ -376,6 +376,9 @@ class Map(object):
                             + 'from layer "%s" which cannot be found'
                             % crop_at_layer)
                     for crop_at in self.layersById[crop_at_layer].features:
+                        # Sometimes a bounding box may not exist, so get it
+                        if not hasattr(crop_at.geom,'bbox'):
+                            crop_at.geom.bbox = geom_to_bbox(crop_at.geom)
                         if crop_at.geom.bbox().intersects(cbbox):
                             tocrop.crop_to(crop_at.geom)
                             cropped_features.append(tocrop)


### PR DESCRIPTION
(https://github.com/kartograph/kartograph.py/blob/master/kartograph/map.py#L379)

adding a check followed by a bbox creation would solve this (pull request coming)
