### PR TITLE
Padding value is wrong if using bbox bounds

### DIFF
--- a/kartograph/map.py
+++ b/kartograph/map.py
@@ -167,7 +167,7 @@ class Map(object):
         if mode == "bbox":  # catch special case bbox
             sea = proj.bounding_geometry(data, projected=True)
             sbbox = geom_to_bbox(sea)
-            sbbox.inflate(sbbox.width * data['padding'])
+            sbbox.inflate(sbbox.width * data['bounds']['padding'])
             return bbox_to_polygon(sbbox)
 
         bbox = BBox()


### PR DESCRIPTION
Hi,

I was getting padding errors when trying to generate maps using bbox bounds and made a minor fix in the map.py code to make it work.

I saw a couple of commits in the last days about a similar issue so I don't know if this fix is already planned or something. 

In that case please ignore this pull request :)
