### PR TITLE
docs: fix simple typo, geoemtry -> geometry

### DIFF
--- a/kartograph/layersource/postgislayer.py
+++ b/kartograph/layersource/postgislayer.py
@@ -34,7 +34,7 @@ class PostGISLayer(LayerSource):
         for rec in cur:
             self.fields.append(rec[0])
 
-        # Find out which column stores the geoemtry data
+        # Find out which column stores the geometry data
         cur.execute("SELECT f_geometry_column FROM geometry_columns WHERE f_table_name = '%s'" % self.table)
         self.geom_col = cur.fetchone()[0]
 


### PR DESCRIPTION
There is a small typo in kartograph/layersource/postgislayer.py.

Should read `geometry` rather than `geoemtry`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md